### PR TITLE
Fix: Remove unused barrel export causing TypeScript errors

### DIFF
--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,6 +1,0 @@
-export { default as Hero } from './Hero.astro';
-export { default as Services } from './Services.astro';
-export { default as About } from './About.astro';
-export { default as Testimonials } from './Testimonials.astro';
-export { default as WhyUs } from './WhyUs.astro';
-export { default as CTA } from './CTA.astro';


### PR DESCRIPTION
## Description

Fixes #5 

This PR removes the unused barrel export file `src/components/sections/index.ts` that was causing 6 TypeScript compilation errors.

## Problem

The file attempted to re-export Astro components using TypeScript, but TypeScript's `tsc` compiler cannot resolve `.astro` module declarations without explicit type definitions. This caused 6 compilation errors:

```
error TS2307: Cannot find module './Hero.astro'
error TS2307: Cannot find module './Services.astro'
error TS2307: Cannot find module './About.astro'
error TS2307: Cannot find module './Testimonials.astro'
error TS2307: Cannot find module './WhyUs.astro'
error TS2307: Cannot find module './CTA.astro'
```

## Solution

Deleted `src/components/sections/index.ts` entirely because:
- No files in the codebase were using the barrel export
- All existing imports use direct paths (e.g., `import Hero from '@/components/sections/Hero.astro'`)
- This aligns with Astro best practices for component imports

## Changes

- **Deleted**: `src/components/sections/index.ts` (7 lines)
- **Modified**: None

## Testing

All verification checks passed:

- ✅ `pnpm tsc --noEmit` - No TypeScript errors (was 6 errors)
- ✅ `pnpm check` - 0 errors, 0 warnings, 0 hints (28 files)
- ✅ `pnpm build` - Successful build, 7 pages generated
- ✅ `pnpm test` - All 30 tests passing

## Impact

- **Breaking Changes**: None (file was unused)
- **Dependencies**: None
- **Performance**: No impact

## Documentation

Detailed documentation available in:
- `.ai/issues/5_Implementation_Plan.md`
- `.ai/issues/5_Implementation_Progress.md`
- `.ai/issues/5_QA_Report.md`