### PR TITLE
Fix: Correct Spanish spelling in CTA heading

### DIFF
--- a/src/components/sections/CTA.astro
+++ b/src/components/sections/CTA.astro
@@ -6,7 +6,7 @@ import { CONTACT } from '@/lib/config';
   class="py-16 lg:py-24 bg-gradient-to-r from-primary-700 to-primary-800 text-white"
 >
   <div class="container text-center">
-    <h2 class="text-3xl lg:text-4xl font-bold mb-6">¡Contratanos!</h2>
+    <h2 class="text-3xl lg:text-4xl font-bold mb-6">¡Contrátanos!</h2>
     <p class="text-lg text-white/90 mb-8 max-w-2xl mx-auto">
       ¿Tienes problemas con tu aire acondicionado, nevera o lavadora? Nuestro
       equipo está listo para ayudarte.


### PR DESCRIPTION
Change 'Contratanos' to 'Contrátanos' to properly include the accent mark
on the second 'a', ensuring grammatically correct Spanish.

Resolves #17