### PR TITLE
Fix: Block analytics in E2E tests to prevent data pollution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,34 @@ playwright test tests/e2e/homepage.spec.ts --grep "should have correct title"
 playwright test tests/e2e/homepage.spec.ts --debug
 ```
 
+#### Analytics Blocking in E2E Tests
+
+All E2E tests automatically block Google Analytics and Google Tag Manager requests to prevent fake test data from polluting production analytics dashboards. This is handled by a custom Playwright fixture located at `tests/e2e/fixtures.ts`.
+
+**How it works:**
+
+- GTM and GA network requests are intercepted and aborted before they complete
+- Analytics scripts still exist in the HTML (so we can verify they're configured)
+- No test data is sent to production analytics platforms
+
+**Important**: Always import test utilities from `./fixtures` instead of `@playwright/test` to ensure analytics blocking is active:
+
+```typescript
+// ✅ Good - analytics automatically blocked
+import { test, expect } from './fixtures';
+
+// ❌ Bad - missing analytics blocking
+import { test, expect } from '@playwright/test';
+```
+
+**Blocked domains:**
+
+- `googletagmanager.com` (GTM scripts)
+- `google-analytics.com` (GA tracking)
+- `analytics.google.com` (Additional GA endpoints)
+
+**Related**: See GitHub Issue #28 for implementation details.
+
 ## Code Style Guidelines
 
 ### Imports

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Blog', () => {
   test.describe('Blog listing page', () => {

--- a/tests/e2e/chatwoot.spec.ts
+++ b/tests/e2e/chatwoot.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Chatwoot', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,53 @@
+import { test as base, expect, type Page } from '@playwright/test';
+
+/**
+ * Custom Playwright test fixture that automatically blocks analytics requests
+ * to prevent E2E tests from sending fake data to production Google Analytics
+ * and Google Tag Manager.
+ *
+ * This fixture extends the base Playwright test and intercepts network requests
+ * to analytics domains, aborting them before they can send data.
+ *
+ * Usage in test files:
+ *   import { test, expect } from './fixtures';
+ *
+ * Blocked domains:
+ * - www.googletagmanager.com (GTM script and iframe)
+ * - www.google-analytics.com (GA tracking)
+ * - analytics.google.com (additional GA endpoints)
+ * - region1.google-analytics.com (regional GA endpoints)
+ * - google-analytics.com (GA fallback)
+ * - googletagmanager.com (GTM fallback)
+ *
+ * Related: GitHub Issue #28
+ */
+
+type TestFixtures = {
+  page: Page;
+};
+
+const test = base.extend<TestFixtures>({
+  page: async ({ page }, use) => {
+    // Block all analytics-related requests before tests run
+    // Use a more flexible matching approach that checks the URL string
+    await page.route('**/*', (route) => {
+      const url = route.request().url();
+      if (
+        url.includes('googletagmanager.com') ||
+        url.includes('google-analytics.com') ||
+        url.includes('analytics.google.com')
+      ) {
+        route.abort();
+      } else {
+        route.continue();
+      }
+    });
+
+    // Use the page in the test
+    await use(page);
+
+    // Cleanup happens automatically after test completes
+  },
+});
+
+export { test, expect };

--- a/tests/e2e/footer.spec.ts
+++ b/tests/e2e/footer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Footer', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Homepage', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('SEO', () => {
   test.describe('Homepage SEO', () => {
@@ -97,6 +97,81 @@ test.describe('SEO', () => {
 
       const h1 = page.getByRole('heading', { level: 1 });
       await expect(h1).toHaveCount(1);
+    });
+  });
+
+  test.describe('Analytics Blocking', () => {
+    test('should block GTM/GA requests in E2E tests', async ({ page }) => {
+      const completedRequests: string[] = [];
+      const failedRequests: string[] = [];
+
+      // Listen for all request completions
+      page.on('requestfinished', (request) => {
+        const url = request.url();
+        if (
+          url.includes('googletagmanager.com') ||
+          url.includes('google-analytics.com') ||
+          url.includes('analytics.google.com')
+        ) {
+          completedRequests.push(url);
+        }
+      });
+
+      // Listen for failed/aborted requests
+      page.on('requestfailed', (request) => {
+        const url = request.url();
+        if (
+          url.includes('googletagmanager.com') ||
+          url.includes('google-analytics.com') ||
+          url.includes('analytics.google.com')
+        ) {
+          failedRequests.push(url);
+        }
+      });
+
+      await page.goto('/');
+
+      // Wait a moment for any scripts to attempt loading
+      await page.waitForTimeout(1000);
+
+      // Log for debugging
+      if (completedRequests.length > 0) {
+        console.log('Completed analytics requests:', completedRequests);
+      }
+      if (failedRequests.length > 0) {
+        console.log('Failed/aborted analytics requests:', failedRequests);
+      }
+
+      // No analytics requests should have completed successfully
+      expect(completedRequests.length).toBe(0);
+
+      // Analytics requests should have been blocked (failed/aborted)
+      expect(failedRequests.length).toBeGreaterThan(0);
+    });
+
+    test('should have GTM script in HTML but not execute', async ({ page }) => {
+      await page.goto('/');
+
+      // Verify the GTM script tag exists in the HTML
+      const pageContent = await page.content();
+      expect(pageContent).toContain('GTM-WGKFDPTD');
+      expect(pageContent).toContain('googletagmanager.com');
+
+      // But the dataLayer should not be populated with GTM events
+      // since the script is blocked from loading
+      const dataLayerExists = await page.evaluate(() => {
+        return typeof window !== 'undefined' && 'dataLayer' in window;
+      });
+
+      // DataLayer might exist but should be empty or minimal
+      // since GTM script never loaded
+      if (dataLayerExists) {
+        const dataLayerLength = await page.evaluate(() => {
+          return (window as any).dataLayer?.length || 0;
+        });
+        // If dataLayer exists, it should be empty or have minimal entries
+        expect(dataLayerLength).toBeLessThanOrEqual(1);
+      }
     });
   });
 });

--- a/tests/e2e/service-pages.spec.ts
+++ b/tests/e2e/service-pages.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 const services = [
   {


### PR DESCRIPTION
## Summary

Implements analytics blocking for E2E tests to prevent fake test data from polluting production Google Analytics and Google Tag Manager dashboards.

**Resolves #28**

## Changes Made

### Core Implementation
- **Created `tests/e2e/fixtures.ts`**: Custom Playwright fixture that automatically blocks GTM/GA network requests
- **Updated all 6 E2E test files**: Changed imports from `@playwright/test` to `./fixtures` to enable automatic blocking
- **Added verification tests**: Two new tests in `seo.spec.ts` to confirm analytics blocking works correctly
- **Updated `AGENTS.md`**: Added comprehensive documentation about analytics blocking in E2E tests

### Technical Approach
- Uses Playwright's `page.route()` to intercept all network requests
- Aborts requests to analytics domains before they complete
- Allows other requests to proceed normally
- Analytics scripts still load in HTML (so we can verify configuration), but network requests are blocked

## Testing Instructions

### Run E2E Tests
```bash
pnpm test:e2e
```

**Expected Results:**
- All 143 tests should pass
- Console output should show: `Failed/aborted analytics requests: [ 'https://www.googletagmanager.com/gtm.js?id=GTM-WGKFDPTD' ]`
- No analytics requests should complete successfully

### Run Specific Verification Tests
```bash
pnpm test:e2e --grep "Analytics Blocking"
```

**Expected Results:**
- Both analytics blocking tests should pass
- Confirms no analytics data sent to production

## Acceptance Criteria

- [x] E2E tests run without triggering real GA/GTM network requests
- [x] Production analytics remain unaffected (no source code changes to analytics components)
- [x] Tests can still verify analytics script presence/configuration
- [x] No fake test data appears in GA/GTM dashboards
- [x] All existing tests continue to pass (143/143 passing)
- [x] Documentation updated

## Files Changed

**Created:**
- `tests/e2e/fixtures.ts` - Custom test fixture with analytics blocking

**Modified:**
- `tests/e2e/blog.spec.ts` - Updated import to use custom fixture
- `tests/e2e/chatwoot.spec.ts` - Updated import to use custom fixture
- `tests/e2e/footer.spec.ts` - Updated import to use custom fixture
- `tests/e2e/homepage.spec.ts` - Updated import to use custom fixture
- `tests/e2e/seo.spec.ts` - Updated import + added verification tests
- `tests/e2e/service-pages.spec.ts` - Updated import to use custom fixture
- `AGENTS.md` - Added analytics blocking documentation

## Blocked Domains

The fixture blocks requests to:
- `googletagmanager.com` (GTM scripts and tracking)
- `google-analytics.com` (GA tracking endpoints)
- `analytics.google.com` (Additional GA endpoints)

## Impact

- **Zero breaking changes**: All existing tests pass without modification
- **Automatic protection**: New tests automatically get analytics blocking
- **Clean architecture**: Test infrastructure handles blocking, not individual tests
- **Performance**: Actually improves test speed slightly (fewer network requests)

## Notes for Reviewers

- The import change from `@playwright/test` to `./fixtures` is intentional and required for analytics blocking
- Analytics scripts still exist in the HTML (this is correct - we want to verify they're configured)
- The verification tests prove that requests are blocked, not just that scripts don't execute
- No changes to production code - only test infrastructure

## Preview

Test output showing successful analytics blocking:
```
Failed/aborted analytics requests: [ 'https://www.googletagmanager.com/gtm.js?id=GTM-WGKFDPTD' ]
  143 passed (26.2s)
```